### PR TITLE
Caching current versions of tags

### DIFF
--- a/lib/rails/cache/tags/local_cache.rb
+++ b/lib/rails/cache/tags/local_cache.rb
@@ -1,0 +1,38 @@
+# coding: utf-8
+
+require 'request_store'
+
+module Rails
+  module Cache
+    module Tags
+      class LocalCache
+        delegate :fetch, :exist?, :[], :[]=, to: :store
+
+        def clear
+          store.clear!
+        end
+
+        private
+
+        def store
+          if RequestStore.active?
+            RequestStore
+          else
+            DummyStore
+          end
+        end
+
+        class DummyStore
+          def self.fetch(_)
+            yield
+          end
+
+          def self.clear!; end
+          def self.exist?(_); end
+          def self.[](_); end
+          def self.[]=(*); end
+        end
+      end # class LocalCache
+    end # module Tags
+  end # module Cache
+end # module Rails

--- a/rails-cache-tags.gemspec
+++ b/rails-cache-tags.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %W(lib)
 
   gem.add_dependency 'activesupport', '>= 3.0'
+  gem.add_dependency 'request_store'
 
   gem.add_development_dependency 'i18n'
   gem.add_development_dependency 'appraisal'


### PR DESCRIPTION
Локальный кеш версий тегов в пределах рельсового запроса.
Позволит значительно уменьшить кол-во запросов в редис.
Например на главной СК, делается 27 запросов к тегу компании, которые не нужны.
В ЕТИ по-моему на каждый из 100 товаров, делается запрос тега компании.
Решит проблему с текстовыми зонами (сколько зон на странице - столько и запросов)

В нашем приложении нет смысла делать повторный запрос на тег посреди страницы.
Кеш работает только в экшенах, в джобах и консоле не работает.
Ожидаю значительный профит.
Проверим, пошлю ПР в оригинальный репозиторий.

![image](https://user-images.githubusercontent.com/1475358/29037166-f0f74688-7bbb-11e7-99c5-4d0e190e8d6e.png)
